### PR TITLE
improve time entry handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # virtualenv
 venv
 __pycache__
+*.pyc
 
 # build
 dist

--- a/hoerapi/util.py
+++ b/hoerapi/util.py
@@ -1,8 +1,12 @@
 from datetime import datetime
+from pytz import timezone
 
 
-def parse_date(str):
-    return datetime.strptime(str, "%Y-%m-%d %H:%M:%S")
+''' zone for time returned by API '''
+DefaultZone = timezone('Europe/Berlin')
+def parse_date(val):
+    val = datetime.strptime(val, "%Y-%m-%d %H:%M:%S")
+    return DefaultZone.localize(val)
 
 
 def parse_bool(str):

--- a/hoerapi/util.py
+++ b/hoerapi/util.py
@@ -1,11 +1,17 @@
 from datetime import datetime
+from iso8601 import parse_date as parse_isodate
 from pytz import timezone
 
 
 ''' zone for time returned by API '''
 DefaultZone = timezone('Europe/Berlin')
 def parse_date(val):
-    val = datetime.strptime(val, "%Y-%m-%d %H:%M:%S")
+    val = parse_isodate(val, DefaultZone)
+    ''' date has ISO zone information '''
+    if val.tzinfo != DefaultZone:
+        return val
+    ''' fix zoneinfo for obtained time '''
+    val = datetime.combine(val.date(), val.time())
     return DefaultZone.localize(val)
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ setup(name='hoerapi',
       url='https://github.com/hoersuppe/hoerapi.py',
       packages=['hoerapi'],
       install_requires=[
-       'requests',
+       'requests', 'pytz',
       ],
      )

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ setup(name='hoerapi',
       url='https://github.com/hoersuppe/hoerapi.py',
       packages=['hoerapi'],
       install_requires=[
-       'requests', 'pytz',
+       'requests', 'pytz', 'iso8601',
       ],
      )

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,10 +1,14 @@
 import pytest
-from hoerapi.util import parse_bool, parse_date
+from hoerapi.util import parse_bool, parse_date, DefaultZone
 from datetime import datetime
-
+from iso8601 import UTC
 
 def test_parse_date():
-    assert parse_date('2012-12-02 13:00:00') == datetime(2012, 12, 2, 13, 0, 0)
+    local = DefaultZone.localize(datetime(2012, 12, 2, 13, 0, 0))
+    utc   = datetime(2012, 12, 2, 13, 0, 0, tzinfo=UTC)
+    assert parse_date('2012-12-02 13:00:00') == local
+    assert parse_date('2012-12-02T13:00:00') == local
+    assert parse_date('2012-12-02T13:00:00Z') == utc
 
 
 @pytest.mark.parametrize("str,bool", [


### PR DESCRIPTION
Hörsuppe API returns times in localtime for `Europe/Berlin` (compare .ical data `X-WR-TIMEZONE`) 

This leads to problems when
- requireing `UTC` timestamps for further processing
- processing data in different timezone

Additionally to solving the (intermediate) timezone-agnostic processing, this solution would handle transition to `UTC` times like `hoerapi.php` would.
The existing date processing made a transition to proper time information for API calls impossible.