### PR TITLE
fix: timezone for "GMT" timestamps

### DIFF
--- a/hoerapi/get_podcast_episodes.py
+++ b/hoerapi/get_podcast_episodes.py
@@ -7,10 +7,12 @@ class PodcastEpisode(CommonEqualityMixin):
     def __init__(self, data):
         self.id = int(data['ID'])
         self.date = parse_date(data['post_date'])
-        self.date_gmt = parse_date(data['post_date_gmt'])
+        gmt = data.get('post_date_gmt')
+        self.date_gmt = parse_date(gmt, 'gmt') if gmt else None
         self.name = data['post_name']
         self.modified = parse_date(data['post_modified'])
-        self.modified_gmt = parse_date(data['post_modified_gmt'])
+        gmt = data.get('post_date_gmt')
+        self.modified_gmt = parse_date(gmt, 'gmt') if gmt else None
         self.link = data['post_link']
         self.commentlink = data['post_commentlink']
         self.mediaurl = data['post_mediaurl']

--- a/hoerapi/util.py
+++ b/hoerapi/util.py
@@ -2,16 +2,18 @@ from datetime import datetime
 from iso8601 import parse_date as parse_isodate
 from pytz import timezone
 
+''' zones for times returned by API '''
+timezone = {
+  'default': timezone('Europe/Berlin'),
+  'gmt': timezone('GMT')
+}
 
-''' zone for time returned by API '''
-DefaultZone = timezone('Europe/Berlin')
-def parse_date(val):
+def parse_date(val, zone='default'):
     val = parse_isodate(val, None)
     ''' date has no ISO zone information '''
     if not val.tzinfo:
-        val = DefaultZone.localize(val)
+        val = timezone[zone].localize(val)
     return val
-
 
 def parse_bool(str):
     if str == "1":

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -30,6 +30,9 @@ def test_get_podcast_data_404():
 
 def test_get_podcast_episodes():
     episodes = hoerapi.get_podcast_episodes('wrint', 2)
+    for e in episodes:
+      assert(e.date == e.date_gmt)
+      assert(e.modified == e.modified_gmt)
     assert len(episodes) == 2
 
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,14 +1,18 @@
 import pytest
-from hoerapi.util import parse_bool, parse_date, DefaultZone
+from hoerapi.util import parse_bool, parse_date, timezone
 from datetime import datetime
 from iso8601 import UTC
 
 def test_parse_date():
-    local = DefaultZone.localize(datetime(2012, 12, 2, 13, 0, 0))
     utc   = datetime(2012, 12, 2, 13, 0, 0, tzinfo=UTC)
+    raw   = datetime(2012, 12, 2, 13, 0, 0)
+    local = timezone['default'].localize(raw)
+    gmt   = timezone['gmt'].localize(raw)
     assert parse_date('2012-12-02 13:00:00') == local
     assert parse_date('2012-12-02T13:00:00') == local
+    assert parse_date('2012-12-02T13:00:00', 'gmt') == gmt
     assert parse_date('2012-12-02T13:00:00Z') == utc
+    assert parse_date('2012-12-02T13:00:00Z', 'gmt') == utc
 
 
 @pytest.mark.parametrize("str,bool", [


### PR DESCRIPTION
Separate handling for `GMT` date properties and appropriate datetime object timezone.
Still hoping for a future where "eccentric" property names (`*_gmt`, really?) and bad date formats are fixed in hoersuppe API…